### PR TITLE
Add date to clarify when the SVN service shutdown.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Additional links:
 Conversion Notes
 ---
 The original source was published as Subversion at
-https://svn.java.net/svn/phoneme~svn. This server is long defunct, but the SVN
-sources were saved to Archive.org as a SVN dump at
+https://svn.java.net/svn/phoneme~svn. This server is long defunct, since
+April 28, 2017, but the SVN sources were saved to Archive.org as a SVN dump at
 https://archive.org/details/phoneme-svn.dump. I have taken this dump and
 massaged it into a sort-of usable git repo. This was trickier than it sounds,
 due to the odd layout of the Subversion repo. For details on the repo layout,


### PR DESCRIPTION
Hi!

I figured a date of when the service actually shutdown. It has been a few years but I believe I actually made the dump sometime in August or September of 2016, which consequently is about half a year since I started work on SquirrelJME.

I suppose some more history on the actual dump. I made the SVN backup I think June-August of 2016, it took about a dozen tries because _Java.net_ was really horrible in that it would often just die for no reason, or it would randomly just kill TCP connections that took too long. In October 2019 someone was talking about PhoneME and how the source code was lost. I actually had a copy of the dump since January 2018 sitting around in my public Keybase account since the last day of 2017. Nobody actually uploaded it to archive.org or have done anything with it so I uploaded to archive.org in October 2019. I initially tried converting the repository to Git on the last day of 2017 but failed because my systems did not have the memory required to convert and it would just fail with out of memory. The hard drive that I backed it up on was actually lost for like half a year and I believe before I took all the data off that it was one of the hard drives that were sitting in a puddle of water for a bit, so PhoneME almost was gone forever.